### PR TITLE
Trace extended data using enhancedDatabaseReporting flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdalmut/opentelemetry-plugin-mongoose",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/spec/utils-spec.ts
+++ b/spec/utils-spec.ts
@@ -1,0 +1,18 @@
+import { safeStringify } from '../src/utils';
+
+describe('utils', () => {
+    describe('safeStringify', () => {
+        it('Stringify as expected', () => {
+            const stringified = safeStringify({ hello: 'world'});
+            expect(stringified).toBe('{"hello":"world"}')
+        })
+
+        it('Fails to stringify a circular object and returns null', () => {
+            const obj: any = { a: 1 };
+            obj.b = obj;
+            const stringified = safeStringify(obj);
+
+            expect(stringified).toBe(null)
+        })
+    })
+})

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -10,6 +10,8 @@ export enum AttributeNames {
   DB_STATEMENT = 'db.statement',
   DB_OPTIONS = 'db.options',
   DB_UPDATE = 'db.updates',
+  DB_SAVE = 'db.save',
+  DB_RESPONSE = 'db.response',
   MONGO_ERROR_CODE = 'db.error_code',
   DB_MODEL = 'db.doc',
   DB_MODEL_NAME = 'mongoose.model',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,3 +38,11 @@ export function setErrorStatus(span: Span, error: MongoError|Error): Span {
 
   return span
 }
+
+export function safeStringify(payload: any): string | null {
+  try {
+    return JSON.stringify(payload);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
When setting `enhancedDatabaseReporting` to true while setting up the plugin, the following data will be traced as well:
*  query exec operations - An attribute called `db.response` will be added to the span, containing the stringified response.
* save operations - An attribute called `db.save` will be added to the span, containing the stringified data that was saved.

The [enhancedDatabaseReporting](https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-api/src/trace/instrumentation/Plugin.ts#L91) flag was chosen out of the allowed list of configs, seemed to most suitable. 

Added test coverage as well.