### PR TITLE
fix: restore span context on async call to query.then

### DIFF
--- a/spec/index-spec.ts
+++ b/spec/index-spec.ts
@@ -616,7 +616,7 @@ describe("mongoose opentelemetry plugin", () => {
       provider.getTracer('default').withSpan(initSpan, async () => {
 
         await User.findOne({id: "_test"});
-        
+
         const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
         expect(spans.length).toBe(1);
         const mongooseSpan: ReadableSpan = spans[0];
@@ -636,7 +636,65 @@ describe("mongoose opentelemetry plugin", () => {
         done()
       })
     })
-    
+
+    it("instrumenting combined operation with Promise.all", async (done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        Promise.all([
+          User
+          .find({id: "_test"})
+          .skip(1)
+          .limit(2)
+          .sort({email: 'asc'}),
+          User.countDocuments()
+        ])
+          .then((users) => {
+            // close the root span
+            span.end()
+
+            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+            // same traceId assertion
+            expect([...new Set(spans.map((span: ReadableSpan) => span.spanContext.traceId))].length).toBe(1)
+
+            expect(spans.length).toBe(3)
+
+            assertSpan(spans[0])
+            assertSpan(spans[1])
+
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toMatch(/^(find|countDocuments)$/g)
+
+            expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toMatch(/^(find|countDocuments)$/g)
+
+            done()
+          })
+      })
+    })
+
+    it("instrumenting combined operation with async/await", async (done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, async () => {
+        await User.find({id: "_test"}).skip(1).limit(2).sort({email: 'asc'})
+        // close the root span
+        span.end()
+
+        const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+        expect(spans.length).toBe(2)
+
+        // same traceId assertion
+        expect([...new Set(spans.map((span: ReadableSpan) => span.spanContext.traceId))].length).toBe(1)
+
+        assertSpan(spans[0])
+
+        expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+        expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('find')
+
+        done()
+      })
+    })
   })
 
   describe("Trace with enhancedDatabaseReporting", () => {

--- a/src/mongoose.ts
+++ b/src/mongoose.ts
@@ -39,7 +39,7 @@ export class MongoosePlugin extends BasePlugin<typeof mongoose> {
     shimmer.wrap(this._moduleExports.Query.prototype, 'exec', this.patchQueryExec());
 
     contextCaptureFunctions.forEach( (funcName: string) => {
-      shimmer.wrap(this._moduleExports.Query.prototype, funcName as any, this.patchAndCaptureSpanContext());
+      shimmer.wrap(this._moduleExports.Query.prototype, funcName as any, this.patchAndCaptureSpanContext(funcName));
     })
 
     shimmer.wrap(this._moduleExports.Query.prototype, 'then', this.patchQueryThen());
@@ -128,9 +128,9 @@ export class MongoosePlugin extends BasePlugin<typeof mongoose> {
     }
   }
 
-  private patchAndCaptureSpanContext() {
+  private patchAndCaptureSpanContext(funcName: string) {
     const thisPlugin = this
-    thisPlugin._logger.debug('MongoosePlugin: patched mongoose query find prototype');
+    thisPlugin._logger.debug(`MongoosePlugin: patched mongoose query ${funcName} prototype`);
     return (original: Function) => {
       return function captureSpanContext(this: any) {
         this._otContext = thisPlugin._tracer.getCurrentSpan();


### PR DESCRIPTION
fixes #29 

mongoose [Query](https://github.com/Automattic/mongoose/blob/master/lib/query.js) object is 'Thenable' - it has a [then](https://github.com/Automattic/mongoose/blob/master/lib/query.js#L4432) function which is called when query is awaited like this: `await User.findOne(...)` (findOne returns a Query object).
This function internally calls the instrumented `exec()` function which [start a new span](https://github.com/wdalmut/opentelemetry-plugin-mongoose/blob/master/src/utils.ts#L7) for the operation. The [startSpan](https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-tracing/src/Tracer.ts#L63) function has `context` parameter, which is not set, thus get [the default value](https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-tracing/src/Tracer.ts#L66) from the `ContextManager` by calling `api.context.active()`

Open telemetry uses the `async_hooks` library to trace async operation and [return the right active context](https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-context-async-hooks/src/AsyncHooksContextManager.ts#L65) across async/await function calls. This behaviour relies on the `asyncHooks.executionAsyncId()` function which works for native promise, but return 0 in case of thenables (at least in the specific context of issue #29), causing the new span in `exec()` to have [root context](https://github.com/open-telemetry/opentelemetry-js/blob/05e7bb9c8fbbc8b36200c3b10b463f331a31a6f7/packages/opentelemetry-context-async-hooks/src/AsyncHooksContextManager.ts#L67) and break the link to it's real parent span.

To fix the issue, I patched the relevant Query functions so they capture the active span for the query, store it on the Query object, and then restore it when `then` is called.

