### PR TITLE
feat: instrument aggregate calls

### DIFF
--- a/spec/index-spec.ts
+++ b/spec/index-spec.ts
@@ -617,7 +617,7 @@ describe("mongoose opentelemetry plugin", () => {
         User.aggregate([
           { $match: { firstName: "John"} },
           { $group: { _id: "John", total: { $sum: "$amount" } } },
-        ]).then((users) => {
+        ]).then(() => {
           const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
           assertSpan(spans[0]);
@@ -638,6 +638,71 @@ describe("mongoose opentelemetry plugin", () => {
 
           done();
         });
+      });
+    });
+
+    it('instrumenting aggregate with callback', async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.aggregate([
+          { $match: { firstName: "John"} },
+          { $group: { _id: "John", total: { $sum: "$amount" } } },
+        ], (error: Error|null, result: any) => {
+          expect(error).toBe(null);
+          expect(result).not.toBe(null);
+
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          assertSpan(spans[0]);
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "aggregate"
+          );
+
+          expect(spans[0].attributes[AttributeNames.DB_AGGREGATE_PIPELINE]).toEqual(
+            '[{"$match":{"firstName":"John"}},{"$group":{"_id":"John","total":{"$sum":"$amount"}}}]'
+          );
+
+          expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
+            "users"
+          );
+
+          done();
+        });
+      });
+    });
+
+    it('instrumenting aggregate with await', async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, async () => {
+        await User.aggregate([
+          { $match: { firstName: "John"} },
+          { $group: { _id: "John", total: { $sum: "$amount" } } },
+        ]);
+
+        const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+        // check linked to parent span correctly
+        expect(spans[0].parentSpanId).toBe(span.context().spanId);
+        
+        assertSpan(spans[0]);
+        expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+          "User"
+        );
+        expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+          "aggregate"
+        );
+
+        expect(spans[0].attributes[AttributeNames.DB_AGGREGATE_PIPELINE]).toEqual(
+          '[{"$match":{"firstName":"John"}},{"$group":{"_id":"John","total":{"$sum":"$amount"}}}]'
+        );
+
+        expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
+          "users"
+        );
+
+        done();
       });
     });
 

--- a/spec/index-spec.ts
+++ b/spec/index-spec.ts
@@ -614,24 +614,26 @@ describe("mongoose opentelemetry plugin", () => {
     it('instrumenting aggregate operation', async (done) => {
       const span = provider.getTracer("default").startSpan("test span");
       provider.getTracer("default").withSpan(span, () => {
-        User.create({
-          firstName: "John",
-          lastName: "Doe",
-          email: "john.doe+1@example.com",
-        }).then(() => {
+        User.aggregate([
+          { $match: { firstName: "John"} },
+          { $group: { _id: "John", total: { $sum: "$amount" } } },
+        ]).then((users) => {
           const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-          expect(spans.length).toBe(1);
           assertSpan(spans[0]);
-
-          expect(spans[0].status.code).toEqual(CanonicalCode.OK);
-
-          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch("");
           expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
             "User"
           );
           expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "save"
+            "aggregate"
+          );
+
+          expect(spans[0].attributes[AttributeNames.DB_AGGREGATE_PIPELINE]).toEqual(
+            '[{"$match":{"firstName":"John"}},{"$group":{"_id":"John","total":{"$sum":"$amount"}}}]'
+          );
+
+          expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
+            "users"
           );
 
           done();

--- a/spec/index-spec.ts
+++ b/spec/index-spec.ts
@@ -1,27 +1,27 @@
 import "jasmine";
 
-import { MongoosePlugin, plugin } from '../src';
-import { AttributeNames } from '../src/enums';
-import { NoopLogger } from '@opentelemetry/core';
-import { NodeTracerProvider } from '@opentelemetry/node';
-import { CanonicalCode, Span } from '@opentelemetry/api';
+import { MongoosePlugin, plugin } from "../src";
+import { AttributeNames } from "../src/enums";
+import { NoopLogger } from "@opentelemetry/core";
+import { NodeTracerProvider } from "@opentelemetry/node";
+import { CanonicalCode, Span } from "@opentelemetry/api";
 
-import mongoose from 'mongoose';
+import mongoose from "mongoose";
 
 const logger = new NoopLogger();
 const provider = new NodeTracerProvider();
 
-import User, { IUser } from './user'
+import User, { IUser } from "./user";
 
-import { context } from '@opentelemetry/api';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { context } from "@opentelemetry/api";
+import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import {
   InMemorySpanExporter,
   ReadableSpan,
   SimpleSpanProcessor,
-} from '@opentelemetry/tracing';
+} from "@opentelemetry/tracing";
 
-import { assertSpan } from './asserts'
+import { assertSpan } from "./asserts";
 
 describe("mongoose opentelemetry plugin", () => {
   beforeAll(async (done) => {
@@ -30,45 +30,44 @@ describe("mongoose opentelemetry plugin", () => {
       useUnifiedTopology: true,
       useFindAndModify: false,
     });
-    done()
+    done();
   });
 
   afterAll(async (done) => {
     await mongoose.connection.close();
-    done()
+    done();
   });
-
 
   beforeEach(async (done) => {
     await User.insertMany([
       new User({
-        firstName: 'John',
-        lastName: 'Doe',
-        email: 'john.doe@example.com',
+        firstName: "John",
+        lastName: "Doe",
+        email: "john.doe@example.com",
         age: 18,
       }),
       new User({
-        firstName: 'Jane',
-        lastName: 'Doe',
-        email: 'jane.doe@example.com',
+        firstName: "Jane",
+        lastName: "Doe",
+        email: "jane.doe@example.com",
         age: 19,
       }),
       new User({
-        firstName: 'Michael',
-        lastName: 'Fox',
-        email: 'michael.fox@example.com',
+        firstName: "Michael",
+        lastName: "Fox",
+        email: "michael.fox@example.com",
         age: 16,
-      })
-    ])
+      }),
+    ]);
 
     User.createIndexes(() => {
-      done()
-    })
-  })
+      done();
+    });
+  });
 
   afterEach(async () => {
     await User.collection.drop();
-  })
+  });
 
   describe("Trace", () => {
     let contextManager: AsyncHooksContextManager;
@@ -78,624 +77,874 @@ describe("mongoose opentelemetry plugin", () => {
 
     beforeAll(() => {
       plugin.enable(mongoose, provider, logger);
-    })
+    });
 
     afterAll(() => {
       plugin.disable();
-    })
+    });
 
     beforeEach(() => {
       memoryExporter.reset();
       contextManager = new AsyncHooksContextManager().enable();
       context.setGlobalContextManager(contextManager);
-    })
+    });
 
     afterEach(() => {
       contextManager.disable();
     });
 
-    it('should export a plugin', () => {
-      expect(plugin instanceof MongoosePlugin).toBe(true)
-    })
-
-    it("instrumenting save operation", async (done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        const user: IUser = new User({
-          firstName: 'Test first name',
-          lastName: 'Test last name',
-          email: 'test@example.com'
-        });
-
-        return user.save()
-      }).then((user) => {
-        const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-        expect(spans.length).toBe(1)
-        assertSpan(spans[0])
-
-        expect(spans[0].status.code).toEqual(CanonicalCode.OK)
-
-        expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch('')
-        expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-        expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('save')
-
-        done()
-      })
-    })
-
-    it("instrumenting save operation with callback", async (done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        const user: IUser = new User({
-          firstName: 'Test first name',
-          lastName: 'Test last name',
-          email: 'test@example.com'
-        });
-
-        user.save(function(err) {
-          if (err) {
-            fail(err)
-            return done()
-          }
-
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-          expect(spans.length).toBe(1)
-          assertSpan(spans[0])
-
-          expect(spans[0].status.code).toEqual(CanonicalCode.OK)
-
-          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch('')
-          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('save')
-
-          done()
-        })
-      })
-    })
-
-    it("instrumenting error on save operation", async (done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        const user: IUser = new User({
-          firstName: 'Test first name',
-          lastName: 'Test last name',
-          email: 'john.doe@example.com'
-        });
-
-        return user.save()
-      })
-      .then((user) => {
-        fail(new Error("should not be possible"))
-        done()
-      })
-      .catch((err) => {
-        const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-        assertSpan(spans[0])
-
-        expect(spans[0].status.code).toEqual(CanonicalCode.UNKNOWN)
-
-        expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch('')
-        expect(spans[0].attributes[AttributeNames.MONGO_ERROR_CODE]).toEqual(11000)
-        expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-        expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('save')
-
-        expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
-
-        done()
-      })
-    })
-
-    it("instrumenting error on save operation with callbacks", async (done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        const user: IUser = new User({
-          firstName: 'Test first name',
-          lastName: 'Test last name',
-          email: 'john.doe@example.com'
-        });
-
-        user.save(function(err) {
-          if (err) {
-            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-            expect(spans.length).toBe(1)
-
-            assertSpan(spans[0])
-
-            expect(spans[0].status.code).toEqual(CanonicalCode.UNKNOWN)
-
-            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch('')
-            expect(spans[0].attributes[AttributeNames.MONGO_ERROR_CODE]).toEqual(11000)
-            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('save')
-
-            expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
-
-            return done()
-          }
-
-          fail(new Error("should not be possible"))
-          done()
-        })
-      })
-    })
-
-    it("instrumenting find operation", async (done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        User.find({id: "_test"})
-          .then((users) => {
-            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-            assertSpan(spans[0])
-            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('find')
-
-            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{"id":"_test"}')
-
-            expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
-
-            done()
-          })
-      })
-    })
-
-    it("instrumenting multiple find operations", async (done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        Promise.all([User.find({id: "_test1"}), User.find({id: "_test2"})])
-          .then((users) => {
-            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-            expect(spans.length).toBe(2)
-
-            assertSpan(spans[0])
-            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('find')
-
-            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch(/^{"id":"_test[1-2]"}$/g)
-
-            expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
-
-            assertSpan(spans[1])
-            expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('find')
-
-            expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toMatch(/^{"id":"_test[1-2]"}$/g)
-
-            expect(spans[1].attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
-
-            done()
-          })
-      })
-    })
-
-    it("instrumenting find operation with chaining structures", async (done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        User
-          .find({id: "_test"})
-          .skip(1)
-          .limit(2)
-          .sort({email: 'asc'})
-          .then((users) => {
-            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-            assertSpan(spans[0])
-            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('find')
-
-            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{"id":"_test"}')
-
-            expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
-
-            done()
-          })
-      })
-    })
-
-    it('instrumenting remove operation [deprecated]', async(done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        User.findOne({email: 'john.doe@example.com'})
-          .then(user => user!.remove())
-          .then(user => {
-            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-            expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toMatch('')
-            expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('remove')
-
-            expect(spans[1].attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
-
-            done()
-          })
-      })
-    })
-
-    it('instrumenting remove operation with callbacks [deprecated]', async(done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, async () => {
-        const user = await User.findOne({email: 'john.doe@example.com'})
-        user!.remove((error: Error|null, user: any) => {
-          expect(error).toBe(null)
-          expect(user).not.toBe(null)
-
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-          expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toMatch('')
-          expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-          expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('remove')
-
-          expect(spans[1].attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
-
-          done()
-        })
-      })
-    })
-
-    it('instrumenting deleteOne operation', async(done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        User.deleteOne({email: 'john.doe@example.com'})
-          .then(op => {
-            expect(op.deletedCount).toBe(1)
-            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-            expect(spans.length).toBe(1)
-
-            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('deleteOne')
-
-            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{"email":"john.doe@example.com"}')
-            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
-            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toBe(undefined)
-            done()
-          })
-      })
-    })
-
-    it('instrumenting updateOne operation on models', async(done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        User.findOne({ email: 'john.doe@example.com' })
-          .then(user => user!.updateOne({ $inc: {age: 1} }, { w: 1 }))
-          .then(user => {
-            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-            expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('updateOne')
-
-            expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toMatch(/{"_id":"\w+"}/)
-            expect(spans[1].attributes[AttributeNames.DB_OPTIONS]).toEqual('{"w":1}')
-            expect(spans[1].attributes[AttributeNames.DB_UPDATE]).toEqual('{"$inc":{"age":1}}')
-
-            expect(spans[1].attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
-
-            done()
-          })
-      })
-    })
-
-    it('instrumenting updateOne operation', async(done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        User.updateOne({ email: 'john.doe@example.com' }, { $inc: {age: 1} })
-          .then(user => {
-            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('updateOne')
-
-            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{"email":"john.doe@example.com"}')
-            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
-            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual('{"$inc":{"age":1}}')
-            done()
-          })
-      })
-    })
-
-    it('instrumenting count operation [deprecated]', async(done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        User.count({})
-          .then(users => {
-            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('count')
-
-            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{}')
-            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
-            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(undefined)
-            done()
-          })
-      })
-    })
-
-    it('instrumenting countDocuments operation', async(done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        User.countDocuments({})
-          .then(users => {
-            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-            expect(spans.length).toBe(1)
-
-            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('countDocuments')
-
-            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{}')
-            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
-            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(undefined)
-            done()
-          })
-      })
-    })
-
-    it('instrumenting estimatedDocumentCount operation', async(done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        User.estimatedDocumentCount({})
-          .then(users => {
-            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-            expect(spans.length).toBe(1)
-
-            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('estimatedDocumentCount')
-
-            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{}')
-            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
-            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(undefined)
-            done()
-          })
-      })
-    })
-
-    it('instrumenting deleteMany operation', async(done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        User.deleteMany({})
-          .then(users => {
-            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('deleteMany')
-
-            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{}')
-            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
-            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(undefined)
-            done()
-          })
-      })
-    })
-
-    it('instrumenting findOne operation', async(done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        User.findOne({ email: 'john.doe@example.com' })
-          .then(user => {
-            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('findOne')
-
-            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch('{"email":"john.doe@example.com"}')
-            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
-            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(undefined)
-            done()
-          })
-      })
-    })
-
-    it('instrumenting update operation', async(done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        User.update({ email: 'john.doe@example.com' }, { email: 'john.doe2@example.com' })
-          .then(user => {
-            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('update')
-
-            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{"email":"john.doe@example.com"}')
-            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
-            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual('{"email":"john.doe2@example.com"}')
-            done()
-          })
-      })
-    })
-
-    it('instrumenting updateMany operation', async(done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        User.updateMany({ age: 18}, { isDeleted: true })
-          .then(user => {
-            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('updateMany')
-
-            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{"age":18}')
-            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
-            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual('{"isDeleted":true}')
-            done()
-          })
-      })
+    it("should export a plugin", () => {
+      expect(plugin instanceof MongoosePlugin).toBe(true);
     });
 
-    it(`instrumenting findOneAndDelete operation`, async(done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        User.findOneAndDelete({ email: "john.doe@example.com" })
-          .then(() => {
+    it("instrumenting save operation", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider
+        .getTracer("default")
+        .withSpan(span, () => {
+          const user: IUser = new User({
+            firstName: "Test first name",
+            lastName: "Test last name",
+            email: "test@example.com",
+          });
+
+          return user.save();
+        })
+        .then((user) => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          expect(spans.length).toBe(1);
+          assertSpan(spans[0]);
+
+          expect(spans[0].status.code).toEqual(CanonicalCode.OK);
+
+          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch("");
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "save"
+          );
+
+          done();
+        });
+    });
+
+    it("instrumenting save operation with callback", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        const user: IUser = new User({
+          firstName: "Test first name",
+          lastName: "Test last name",
+          email: "test@example.com",
+        });
+
+        user.save(function (err) {
+          if (err) {
+            fail(err);
+            return done();
+          }
+
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          expect(spans.length).toBe(1);
+          assertSpan(spans[0]);
+
+          expect(spans[0].status.code).toEqual(CanonicalCode.OK);
+
+          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch("");
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "save"
+          );
+
+          done();
+        });
+      });
+    });
+
+    it("instrumenting error on save operation", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider
+        .getTracer("default")
+        .withSpan(span, () => {
+          const user: IUser = new User({
+            firstName: "Test first name",
+            lastName: "Test last name",
+            email: "john.doe@example.com",
+          });
+
+          return user.save();
+        })
+        .then((user) => {
+          fail(new Error("should not be possible"));
+          done();
+        })
+        .catch((err) => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          assertSpan(spans[0]);
+
+          expect(spans[0].status.code).toEqual(CanonicalCode.UNKNOWN);
+
+          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch("");
+          expect(spans[0].attributes[AttributeNames.MONGO_ERROR_CODE]).toEqual(
+            11000
+          );
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "save"
+          );
+
+          expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
+            "users"
+          );
+
+          done();
+        });
+    });
+
+    it("instrumenting error on save operation with callbacks", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        const user: IUser = new User({
+          firstName: "Test first name",
+          lastName: "Test last name",
+          email: "john.doe@example.com",
+        });
+
+        user.save(function (err) {
+          if (err) {
             const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-            expect(spans.length).toBe(1)
+            expect(spans.length).toBe(1);
 
-            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('findOneAndDelete')
+            assertSpan(spans[0]);
 
-            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{"email":"john.doe@example.com"}')
-            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
-            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(undefined)
-            done()
-          })
-      })
-    })
+            expect(spans[0].status.code).toEqual(CanonicalCode.UNKNOWN);
 
-    it(`instrumenting findOneAndUpdate operation`, async(done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        User.findOneAndUpdate({ email: "john.doe@example.com" }, { isUpdated: true } )
-          .then(() => {
+            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch(
+              ""
+            );
+            expect(
+              spans[0].attributes[AttributeNames.MONGO_ERROR_CODE]
+            ).toEqual(11000);
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+              "User"
+            );
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+              "save"
+            );
+
+            expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
+              "users"
+            );
+
+            return done();
+          }
+
+          fail(new Error("should not be possible"));
+          done();
+        });
+      });
+    });
+
+    it("instrumenting find operation", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.find({ id: "_test" }).then((users) => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          assertSpan(spans[0]);
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "find"
+          );
+
+          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
+            '{"id":"_test"}'
+          );
+
+          expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
+            "users"
+          );
+
+          done();
+        });
+      });
+    });
+
+    it("instrumenting multiple find operations", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        Promise.all([
+          User.find({ id: "_test1" }),
+          User.find({ id: "_test2" }),
+        ]).then((users) => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          expect(spans.length).toBe(2);
+
+          assertSpan(spans[0]);
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "find"
+          );
+
+          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch(
+            /^{"id":"_test[1-2]"}$/g
+          );
+
+          expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
+            "users"
+          );
+
+          assertSpan(spans[1]);
+          expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "find"
+          );
+
+          expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toMatch(
+            /^{"id":"_test[1-2]"}$/g
+          );
+
+          expect(spans[1].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
+            "users"
+          );
+
+          done();
+        });
+      });
+    });
+
+    it("instrumenting find operation with chaining structures", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.find({ id: "_test" })
+          .skip(1)
+          .limit(2)
+          .sort({ email: "asc" })
+          .then((users) => {
             const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-            expect(spans.length).toBe(2)
+            assertSpan(spans[0]);
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+              "User"
+            );
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+              "find"
+            );
 
-            expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('findOneAndUpdate')
+            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
+              '{"id":"_test"}'
+            );
 
-            expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toEqual('{"email":"john.doe@example.com"}')
-            expect(spans[1].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
-            expect(spans[1].attributes[AttributeNames.DB_UPDATE]).toEqual('{"isUpdated":true}')
+            expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
+              "users"
+            );
 
-            done()
-          })
-      })
-    })
+            done();
+          });
+      });
+    });
 
-    it(`instrumenting findOneAndRemove operation`, async(done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        User.findOneAndRemove({ email: "john.doe@example.com" } )
-          .then(() => {
+    it("instrumenting remove operation [deprecated]", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.findOne({ email: "john.doe@example.com" })
+          .then((user) => user!.remove())
+          .then((user) => {
             const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-            expect(spans.length).toBe(1)
+            expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toMatch(
+              ""
+            );
+            expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+              "User"
+            );
+            expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+              "remove"
+            );
 
-            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('findOneAndRemove')
+            expect(spans[1].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
+              "users"
+            );
 
-            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{"email":"john.doe@example.com"}')
-            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
-            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(undefined)
+            done();
+          });
+      });
+    });
 
-            done()
-          })
-      })
-    })
+    it("instrumenting remove operation with callbacks [deprecated]", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, async () => {
+        const user = await User.findOne({ email: "john.doe@example.com" });
+        user!.remove((error: Error | null, user: any) => {
+          expect(error).toBe(null);
+          expect(user).not.toBe(null);
 
-    it(`instrumenting create operation`, async(done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        User.create({ firstName: 'John', lastName: 'Doe', email: "john.doe+1@example.com" } )
-          .then(() => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toMatch("");
+          expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "remove"
+          );
+
+          expect(spans[1].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
+            "users"
+          );
+
+          done();
+        });
+      });
+    });
+
+    it("instrumenting deleteOne operation", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.deleteOne({ email: "john.doe@example.com" }).then((op) => {
+          expect(op.deletedCount).toBe(1);
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          expect(spans.length).toBe(1);
+
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "deleteOne"
+          );
+
+          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
+            '{"email":"john.doe@example.com"}'
+          );
+          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
+          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toBe(undefined);
+          done();
+        });
+      });
+    });
+
+    it("instrumenting updateOne operation on models", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.findOne({ email: "john.doe@example.com" })
+          .then((user) => user!.updateOne({ $inc: { age: 1 } }, { w: 1 }))
+          .then((user) => {
             const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-            expect(spans.length).toBe(1)
-            assertSpan(spans[0])
+            expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+              "User"
+            );
+            expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+              "updateOne"
+            );
 
-            expect(spans[0].status.code).toEqual(CanonicalCode.OK)
+            expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toMatch(
+              /{"_id":"\w+"}/
+            );
+            expect(spans[1].attributes[AttributeNames.DB_OPTIONS]).toEqual(
+              '{"w":1}'
+            );
+            expect(spans[1].attributes[AttributeNames.DB_UPDATE]).toEqual(
+              '{"$inc":{"age":1}}'
+            );
 
-            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch('')
-            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('save')
+            expect(spans[1].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
+              "users"
+            );
 
-            done()
-          })
-      })
-    })
+            done();
+          });
+      });
+    });
+
+    it("instrumenting updateOne operation", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.updateOne(
+          { email: "john.doe@example.com" },
+          { $inc: { age: 1 } }
+        ).then((user) => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "updateOne"
+          );
+
+          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
+            '{"email":"john.doe@example.com"}'
+          );
+          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
+          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
+            '{"$inc":{"age":1}}'
+          );
+          done();
+        });
+      });
+    });
+
+    it("instrumenting count operation [deprecated]", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.count({}).then((users) => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "count"
+          );
+
+          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
+            "{}"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
+          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
+            undefined
+          );
+          done();
+        });
+      });
+    });
+
+    it("instrumenting countDocuments operation", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.countDocuments({}).then((users) => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          expect(spans.length).toBe(1);
+
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "countDocuments"
+          );
+
+          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
+            "{}"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
+          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
+            undefined
+          );
+          done();
+        });
+      });
+    });
+
+    it("instrumenting estimatedDocumentCount operation", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.estimatedDocumentCount({}).then((users) => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          expect(spans.length).toBe(1);
+
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "estimatedDocumentCount"
+          );
+
+          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
+            "{}"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
+          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
+            undefined
+          );
+          done();
+        });
+      });
+    });
+
+    it("instrumenting deleteMany operation", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.deleteMany({}).then((users) => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "deleteMany"
+          );
+
+          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
+            "{}"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
+          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
+            undefined
+          );
+          done();
+        });
+      });
+    });
+
+    it("instrumenting findOne operation", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.findOne({ email: "john.doe@example.com" }).then((user) => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "findOne"
+          );
+
+          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch(
+            '{"email":"john.doe@example.com"}'
+          );
+          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
+          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
+            undefined
+          );
+          done();
+        });
+      });
+    });
+
+    it("instrumenting update operation", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.update(
+          { email: "john.doe@example.com" },
+          { email: "john.doe2@example.com" }
+        ).then((user) => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "update"
+          );
+
+          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
+            '{"email":"john.doe@example.com"}'
+          );
+          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
+          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
+            '{"email":"john.doe2@example.com"}'
+          );
+          done();
+        });
+      });
+    });
+
+    it("instrumenting updateMany operation", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.updateMany({ age: 18 }, { isDeleted: true }).then((user) => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "updateMany"
+          );
+
+          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
+            '{"age":18}'
+          );
+          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
+          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
+            '{"isDeleted":true}'
+          );
+          done();
+        });
+      });
+    });
+
+    it(`instrumenting findOneAndDelete operation`, async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.findOneAndDelete({ email: "john.doe@example.com" }).then(() => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          expect(spans.length).toBe(1);
+
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "findOneAndDelete"
+          );
+
+          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
+            '{"email":"john.doe@example.com"}'
+          );
+          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
+          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
+            undefined
+          );
+          done();
+        });
+      });
+    });
+
+    it(`instrumenting findOneAndUpdate operation`, async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.findOneAndUpdate(
+          { email: "john.doe@example.com" },
+          { isUpdated: true }
+        ).then(() => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          expect(spans.length).toBe(2);
+
+          expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "findOneAndUpdate"
+          );
+
+          expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toEqual(
+            '{"email":"john.doe@example.com"}'
+          );
+          expect(spans[1].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
+          expect(spans[1].attributes[AttributeNames.DB_UPDATE]).toEqual(
+            '{"isUpdated":true}'
+          );
+
+          done();
+        });
+      });
+    });
+
+    it(`instrumenting findOneAndRemove operation`, async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.findOneAndRemove({ email: "john.doe@example.com" }).then(() => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          expect(spans.length).toBe(1);
+
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "findOneAndRemove"
+          );
+
+          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
+            '{"email":"john.doe@example.com"}'
+          );
+          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
+          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
+            undefined
+          );
+
+          done();
+        });
+      });
+    });
+
+    it(`instrumenting create operation`, async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.create({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john.doe+1@example.com",
+        }).then(() => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          expect(spans.length).toBe(1);
+          assertSpan(spans[0]);
+
+          expect(spans[0].status.code).toEqual(CanonicalCode.OK);
+
+          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch("");
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "save"
+          );
+
+          done();
+        });
+      });
+    });
+
+    it("instrumenting aggregate operation", async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.aggregate([
+          { $match: { firstName: "John"} },
+          { $group: { _id: "John", total: { $sum: "$amount" } } },
+        ]).then((users) => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+          assertSpan(spans[0]);
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+            "aggregate"
+          );
+
+          expect(spans[0].attributes[AttributeNames.DB_AGGREGATE_PIPELINE]).toEqual(
+            '[{"$match":{"firstName":"John"}},{"$group":{"_id":"John","total":{"$sum":"$amount"}}}]'
+          );
+
+          expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
+            "users"
+          );
+
+          done();
+        });
+      });
+    });
 
     it("await on mongoose thenable query object", async (done) => {
-      const initSpan: Span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(initSpan, async () => {
-
-        await User.findOne({id: "_test"});
+      const initSpan: Span = provider
+        .getTracer("default")
+        .startSpan("test span");
+      provider.getTracer("default").withSpan(initSpan, async () => {
+        await User.findOne({ id: "_test" });
 
         const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
         expect(spans.length).toBe(1);
         const mongooseSpan: ReadableSpan = spans[0];
 
         // validate the the mongoose span is the child of the span the initiated the call
-        expect(mongooseSpan.spanContext.traceId).toEqual(initSpan.context().traceId);
+        expect(mongooseSpan.spanContext.traceId).toEqual(
+          initSpan.context().traceId
+        );
         expect(mongooseSpan.parentSpanId).toEqual(initSpan.context().spanId);
 
         assertSpan(mongooseSpan);
-        expect(mongooseSpan.attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-        expect(mongooseSpan.attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('findOne')
+        expect(mongooseSpan.attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+          "User"
+        );
+        expect(mongooseSpan.attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+          "findOne"
+        );
 
-        expect(mongooseSpan.attributes[AttributeNames.DB_STATEMENT]).toEqual('{"id":"_test"}')
+        expect(mongooseSpan.attributes[AttributeNames.DB_STATEMENT]).toEqual(
+          '{"id":"_test"}'
+        );
 
-        expect(mongooseSpan.attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
+        expect(mongooseSpan.attributes[AttributeNames.COLLECTION_NAME]).toEqual(
+          "users"
+        );
 
-        done()
-      })
-    })
+        done();
+      });
+    });
 
     it("instrumenting combined operation with Promise.all", async (done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
         Promise.all([
-          User
-          .find({id: "_test"})
-          .skip(1)
-          .limit(2)
-          .sort({email: 'asc'}),
-          User.countDocuments()
-        ])
-          .then((users) => {
-            // close the root span
-            span.end()
+          User.find({ id: "_test" }).skip(1).limit(2).sort({ email: "asc" }),
+          User.countDocuments(),
+        ]).then((users) => {
+          // close the root span
+          span.end();
 
-            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-            // same traceId assertion
-            expect([...new Set(spans.map((span: ReadableSpan) => span.spanContext.traceId))].length).toBe(1)
+          // same traceId assertion
+          expect(
+            [
+              ...new Set(
+                spans.map((span: ReadableSpan) => span.spanContext.traceId)
+              ),
+            ].length
+          ).toBe(1);
 
-            expect(spans.length).toBe(3)
+          expect(spans.length).toBe(3);
 
-            assertSpan(spans[0])
-            assertSpan(spans[1])
+          assertSpan(spans[0]);
+          assertSpan(spans[1]);
 
-            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toMatch(/^(find|countDocuments)$/g)
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toMatch(
+            /^(find|countDocuments)$/g
+          );
 
-            expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-            expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toMatch(/^(find|countDocuments)$/g)
+          expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+            "User"
+          );
+          expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toMatch(
+            /^(find|countDocuments)$/g
+          );
 
-            done()
-          })
-      })
-    })
+          done();
+        });
+      });
+    });
 
     it("instrumenting combined operation with async/await", async (done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, async () => {
-        await User.find({id: "_test"}).skip(1).limit(2).sort({email: 'asc'})
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, async () => {
+        await User.find({ id: "_test" })
+          .skip(1)
+          .limit(2)
+          .sort({ email: "asc" });
         // close the root span
-        span.end()
+        span.end();
 
         const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-        expect(spans.length).toBe(2)
+        expect(spans.length).toBe(2);
 
         // same traceId assertion
-        expect([...new Set(spans.map((span: ReadableSpan) => span.spanContext.traceId))].length).toBe(1)
+        expect(
+          [
+            ...new Set(
+              spans.map((span: ReadableSpan) => span.spanContext.traceId)
+            ),
+          ].length
+        ).toBe(1);
 
-        assertSpan(spans[0])
+        assertSpan(spans[0]);
 
-        expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
-        expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('find')
+        expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
+          "User"
+        );
+        expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
+          "find"
+        );
 
-        done()
-      })
-    })
-  })
+        done();
+      });
+    });
+  });
 
   describe("Trace with enhancedDatabaseReporting", () => {
     let contextManager: AsyncHooksContextManager;
@@ -704,58 +953,65 @@ describe("mongoose opentelemetry plugin", () => {
     provider.addSpanProcessor(spanProcessor);
 
     beforeAll(() => {
-      plugin.enable(mongoose, provider, logger, { enhancedDatabaseReporting: true });
-    })
+      plugin.enable(mongoose, provider, logger, {
+        enhancedDatabaseReporting: true,
+      });
+    });
 
     afterAll(() => {
       plugin.disable();
-    })
+    });
 
     beforeEach(() => {
       memoryExporter.reset();
       contextManager = new AsyncHooksContextManager().enable();
       context.setGlobalContextManager(contextManager);
-    })
+    });
 
     afterEach(() => {
       contextManager.disable();
     });
 
-    it(`Save operation traces save data`, async(done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        const payload = { firstName: 'John', lastName: 'Doe', email: "john.doe+1@example.com" };
-        User.create(payload)
-          .then((user) => {
-            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+    it(`Save operation traces save data`, async (done) => {
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        const payload = {
+          firstName: "John",
+          lastName: "Doe",
+          email: "john.doe+1@example.com",
+        };
+        User.create(payload).then((user) => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-            expect(spans.length).toBe(1)
-            assertSpan(spans[0])
+          expect(spans.length).toBe(1);
+          assertSpan(spans[0]);
 
-            const saveData = JSON.parse(spans[0].attributes[AttributeNames.DB_SAVE] as string);
-            expect(saveData.firstName).toBe(payload.firstName);
-            expect(saveData.lastName).toBe(payload.lastName);
-            expect(saveData.email).toBe(payload.email);
-            expect(saveData._id).toBeDefined();
+          const saveData = JSON.parse(
+            spans[0].attributes[AttributeNames.DB_SAVE] as string
+          );
+          expect(saveData.firstName).toBe(payload.firstName);
+          expect(saveData.lastName).toBe(payload.lastName);
+          expect(saveData.email).toBe(payload.email);
+          expect(saveData._id).toBeDefined();
 
-            done()
-          })
+          done();
+        });
       });
     });
 
     it("find operation traces query response", async (done) => {
-      const span = provider.getTracer('default').startSpan('test span');
-      provider.getTracer('default').withSpan(span, () => {
-        User.find({})
-          .then((users) => {
-            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-            assertSpan(spans[0]);
-            expect(JSON.stringify(users)).toEqual(spans[0].attributes[AttributeNames.DB_RESPONSE] as string);
+      const span = provider.getTracer("default").startSpan("test span");
+      provider.getTracer("default").withSpan(span, () => {
+        User.find({}).then((users) => {
+          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+          assertSpan(spans[0]);
+          expect(JSON.stringify(users)).toEqual(
+            spans[0].attributes[AttributeNames.DB_RESPONSE] as string
+          );
 
-            done()
-          })
-      })
-    })
-
-  })
+          done();
+        });
+      });
+    });
+  });
 });

--- a/spec/index-spec.ts
+++ b/spec/index-spec.ts
@@ -1,27 +1,27 @@
 import "jasmine";
 
-import { MongoosePlugin, plugin } from "../src";
-import { AttributeNames } from "../src/enums";
-import { NoopLogger } from "@opentelemetry/core";
-import { NodeTracerProvider } from "@opentelemetry/node";
-import { CanonicalCode, Span } from "@opentelemetry/api";
+import { MongoosePlugin, plugin } from '../src';
+import { AttributeNames } from '../src/enums';
+import { NoopLogger } from '@opentelemetry/core';
+import { NodeTracerProvider } from '@opentelemetry/node';
+import { CanonicalCode, Span } from '@opentelemetry/api';
 
-import mongoose from "mongoose";
+import mongoose from 'mongoose';
 
 const logger = new NoopLogger();
 const provider = new NodeTracerProvider();
 
-import User, { IUser } from "./user";
+import User, { IUser } from './user'
 
-import { context } from "@opentelemetry/api";
-import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
+import { context } from '@opentelemetry/api';
+import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import {
   InMemorySpanExporter,
   ReadableSpan,
   SimpleSpanProcessor,
-} from "@opentelemetry/tracing";
+} from '@opentelemetry/tracing';
 
-import { assertSpan } from "./asserts";
+import { assertSpan } from './asserts'
 
 describe("mongoose opentelemetry plugin", () => {
   beforeAll(async (done) => {
@@ -30,44 +30,45 @@ describe("mongoose opentelemetry plugin", () => {
       useUnifiedTopology: true,
       useFindAndModify: false,
     });
-    done();
+    done()
   });
 
   afterAll(async (done) => {
     await mongoose.connection.close();
-    done();
+    done()
   });
+
 
   beforeEach(async (done) => {
     await User.insertMany([
       new User({
-        firstName: "John",
-        lastName: "Doe",
-        email: "john.doe@example.com",
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john.doe@example.com',
         age: 18,
       }),
       new User({
-        firstName: "Jane",
-        lastName: "Doe",
-        email: "jane.doe@example.com",
+        firstName: 'Jane',
+        lastName: 'Doe',
+        email: 'jane.doe@example.com',
         age: 19,
       }),
       new User({
-        firstName: "Michael",
-        lastName: "Fox",
-        email: "michael.fox@example.com",
+        firstName: 'Michael',
+        lastName: 'Fox',
+        email: 'michael.fox@example.com',
         age: 16,
-      }),
-    ]);
+      })
+    ])
 
     User.createIndexes(() => {
-      done();
-    });
-  });
+      done()
+    })
+  })
 
   afterEach(async () => {
     await User.collection.drop();
-  });
+  })
 
   describe("Trace", () => {
     let contextManager: AsyncHooksContextManager;
@@ -77,725 +78,538 @@ describe("mongoose opentelemetry plugin", () => {
 
     beforeAll(() => {
       plugin.enable(mongoose, provider, logger);
-    });
+    })
 
     afterAll(() => {
       plugin.disable();
-    });
+    })
 
     beforeEach(() => {
       memoryExporter.reset();
       contextManager = new AsyncHooksContextManager().enable();
       context.setGlobalContextManager(contextManager);
-    });
+    })
 
     afterEach(() => {
       contextManager.disable();
     });
 
-    it("should export a plugin", () => {
-      expect(plugin instanceof MongoosePlugin).toBe(true);
-    });
+    it('should export a plugin', () => {
+      expect(plugin instanceof MongoosePlugin).toBe(true)
+    })
 
     it("instrumenting save operation", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider
-        .getTracer("default")
-        .withSpan(span, () => {
-          const user: IUser = new User({
-            firstName: "Test first name",
-            lastName: "Test last name",
-            email: "test@example.com",
-          });
-
-          return user.save();
-        })
-        .then((user) => {
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-          expect(spans.length).toBe(1);
-          assertSpan(spans[0]);
-
-          expect(spans[0].status.code).toEqual(CanonicalCode.OK);
-
-          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch("");
-          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "save"
-          );
-
-          done();
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        const user: IUser = new User({
+          firstName: 'Test first name',
+          lastName: 'Test last name',
+          email: 'test@example.com'
         });
-    });
+
+        return user.save()
+      }).then((user) => {
+        const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+        expect(spans.length).toBe(1)
+        assertSpan(spans[0])
+
+        expect(spans[0].status.code).toEqual(CanonicalCode.OK)
+
+        expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch('')
+        expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+        expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('save')
+
+        done()
+      })
+    })
 
     it("instrumenting save operation with callback", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
         const user: IUser = new User({
-          firstName: "Test first name",
-          lastName: "Test last name",
-          email: "test@example.com",
+          firstName: 'Test first name',
+          lastName: 'Test last name',
+          email: 'test@example.com'
         });
 
-        user.save(function (err) {
+        user.save(function(err) {
           if (err) {
-            fail(err);
-            return done();
+            fail(err)
+            return done()
           }
 
           const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-          expect(spans.length).toBe(1);
-          assertSpan(spans[0]);
+          expect(spans.length).toBe(1)
+          assertSpan(spans[0])
 
-          expect(spans[0].status.code).toEqual(CanonicalCode.OK);
+          expect(spans[0].status.code).toEqual(CanonicalCode.OK)
 
-          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch("");
-          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "save"
-          );
+          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch('')
+          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('save')
 
-          done();
-        });
-      });
-    });
+          done()
+        })
+      })
+    })
 
     it("instrumenting error on save operation", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider
-        .getTracer("default")
-        .withSpan(span, () => {
-          const user: IUser = new User({
-            firstName: "Test first name",
-            lastName: "Test last name",
-            email: "john.doe@example.com",
-          });
-
-          return user.save();
-        })
-        .then((user) => {
-          fail(new Error("should not be possible"));
-          done();
-        })
-        .catch((err) => {
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-          assertSpan(spans[0]);
-
-          expect(spans[0].status.code).toEqual(CanonicalCode.UNKNOWN);
-
-          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch("");
-          expect(spans[0].attributes[AttributeNames.MONGO_ERROR_CODE]).toEqual(
-            11000
-          );
-          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "save"
-          );
-
-          expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
-            "users"
-          );
-
-          done();
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        const user: IUser = new User({
+          firstName: 'Test first name',
+          lastName: 'Test last name',
+          email: 'john.doe@example.com'
         });
-    });
+
+        return user.save()
+      })
+      .then((user) => {
+        fail(new Error("should not be possible"))
+        done()
+      })
+      .catch((err) => {
+        const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+        assertSpan(spans[0])
+
+        expect(spans[0].status.code).toEqual(CanonicalCode.UNKNOWN)
+
+        expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch('')
+        expect(spans[0].attributes[AttributeNames.MONGO_ERROR_CODE]).toEqual(11000)
+        expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+        expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('save')
+
+        expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
+
+        done()
+      })
+    })
 
     it("instrumenting error on save operation with callbacks", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
         const user: IUser = new User({
-          firstName: "Test first name",
-          lastName: "Test last name",
-          email: "john.doe@example.com",
+          firstName: 'Test first name',
+          lastName: 'Test last name',
+          email: 'john.doe@example.com'
         });
 
-        user.save(function (err) {
+        user.save(function(err) {
           if (err) {
             const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-            expect(spans.length).toBe(1);
+            expect(spans.length).toBe(1)
 
-            assertSpan(spans[0]);
+            assertSpan(spans[0])
 
-            expect(spans[0].status.code).toEqual(CanonicalCode.UNKNOWN);
+            expect(spans[0].status.code).toEqual(CanonicalCode.UNKNOWN)
 
-            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch(
-              ""
-            );
-            expect(
-              spans[0].attributes[AttributeNames.MONGO_ERROR_CODE]
-            ).toEqual(11000);
-            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-              "User"
-            );
-            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-              "save"
-            );
+            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch('')
+            expect(spans[0].attributes[AttributeNames.MONGO_ERROR_CODE]).toEqual(11000)
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('save')
 
-            expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
-              "users"
-            );
+            expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
 
-            return done();
+            return done()
           }
 
-          fail(new Error("should not be possible"));
-          done();
-        });
-      });
-    });
+          fail(new Error("should not be possible"))
+          done()
+        })
+      })
+    })
 
     it("instrumenting find operation", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        User.find({ id: "_test" }).then((users) => {
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-          assertSpan(spans[0]);
-          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "find"
-          );
-
-          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
-            '{"id":"_test"}'
-          );
-
-          expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
-            "users"
-          );
-
-          done();
-        });
-      });
-    });
-
-    it("instrumenting multiple find operations", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        Promise.all([
-          User.find({ id: "_test1" }),
-          User.find({ id: "_test2" }),
-        ]).then((users) => {
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-          expect(spans.length).toBe(2);
-
-          assertSpan(spans[0]);
-          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "find"
-          );
-
-          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch(
-            /^{"id":"_test[1-2]"}$/g
-          );
-
-          expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
-            "users"
-          );
-
-          assertSpan(spans[1]);
-          expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "find"
-          );
-
-          expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toMatch(
-            /^{"id":"_test[1-2]"}$/g
-          );
-
-          expect(spans[1].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
-            "users"
-          );
-
-          done();
-        });
-      });
-    });
-
-    it("instrumenting find operation with chaining structures", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        User.find({ id: "_test" })
-          .skip(1)
-          .limit(2)
-          .sort({ email: "asc" })
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        User.find({id: "_test"})
           .then((users) => {
             const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-            assertSpan(spans[0]);
-            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-              "User"
-            );
-            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-              "find"
-            );
+            assertSpan(spans[0])
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('find')
 
-            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
-              '{"id":"_test"}'
-            );
+            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{"id":"_test"}')
 
-            expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
-              "users"
-            );
+            expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
 
-            done();
-          });
-      });
-    });
+            done()
+          })
+      })
+    })
 
-    it("instrumenting remove operation [deprecated]", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        User.findOne({ email: "john.doe@example.com" })
-          .then((user) => user!.remove())
-          .then((user) => {
+    it("instrumenting multiple find operations", async (done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        Promise.all([User.find({id: "_test1"}), User.find({id: "_test2"})])
+          .then((users) => {
             const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-            expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toMatch(
-              ""
-            );
-            expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-              "User"
-            );
-            expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-              "remove"
-            );
+            expect(spans.length).toBe(2)
 
-            expect(spans[1].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
-              "users"
-            );
+            assertSpan(spans[0])
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('find')
 
-            done();
-          });
-      });
-    });
+            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch(/^{"id":"_test[1-2]"}$/g)
 
-    it("instrumenting remove operation with callbacks [deprecated]", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, async () => {
-        const user = await User.findOne({ email: "john.doe@example.com" });
-        user!.remove((error: Error | null, user: any) => {
-          expect(error).toBe(null);
-          expect(user).not.toBe(null);
+            expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
 
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+            assertSpan(spans[1])
+            expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('find')
 
-          expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toMatch("");
-          expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "remove"
-          );
+            expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toMatch(/^{"id":"_test[1-2]"}$/g)
 
-          expect(spans[1].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
-            "users"
-          );
+            expect(spans[1].attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
 
-          done();
-        });
-      });
-    });
+            done()
+          })
+      })
+    })
 
-    it("instrumenting deleteOne operation", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        User.deleteOne({ email: "john.doe@example.com" }).then((op) => {
-          expect(op.deletedCount).toBe(1);
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-          expect(spans.length).toBe(1);
-
-          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "deleteOne"
-          );
-
-          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
-            '{"email":"john.doe@example.com"}'
-          );
-          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
-          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toBe(undefined);
-          done();
-        });
-      });
-    });
-
-    it("instrumenting updateOne operation on models", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        User.findOne({ email: "john.doe@example.com" })
-          .then((user) => user!.updateOne({ $inc: { age: 1 } }, { w: 1 }))
-          .then((user) => {
+    it("instrumenting find operation with chaining structures", async (done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        User
+          .find({id: "_test"})
+          .skip(1)
+          .limit(2)
+          .sort({email: 'asc'})
+          .then((users) => {
             const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-            expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-              "User"
-            );
-            expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-              "updateOne"
-            );
+            assertSpan(spans[0])
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('find')
 
-            expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toMatch(
-              /{"_id":"\w+"}/
-            );
-            expect(spans[1].attributes[AttributeNames.DB_OPTIONS]).toEqual(
-              '{"w":1}'
-            );
-            expect(spans[1].attributes[AttributeNames.DB_UPDATE]).toEqual(
-              '{"$inc":{"age":1}}'
-            );
+            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{"id":"_test"}')
 
-            expect(spans[1].attributes[AttributeNames.COLLECTION_NAME]).toEqual(
-              "users"
-            );
+            expect(spans[0].attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
 
-            done();
-          });
-      });
-    });
+            done()
+          })
+      })
+    })
 
-    it("instrumenting updateOne operation", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        User.updateOne(
-          { email: "john.doe@example.com" },
-          { $inc: { age: 1 } }
-        ).then((user) => {
+    it('instrumenting remove operation [deprecated]', async(done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        User.findOne({email: 'john.doe@example.com'})
+          .then(user => user!.remove())
+          .then(user => {
+            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+            expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toMatch('')
+            expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('remove')
+
+            expect(spans[1].attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
+
+            done()
+          })
+      })
+    })
+
+    it('instrumenting remove operation with callbacks [deprecated]', async(done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, async () => {
+        const user = await User.findOne({email: 'john.doe@example.com'})
+        user!.remove((error: Error|null, user: any) => {
+          expect(error).toBe(null)
+          expect(user).not.toBe(null)
+
           const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "updateOne"
-          );
+          expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toMatch('')
+          expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+          expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('remove')
 
-          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
-            '{"email":"john.doe@example.com"}'
-          );
-          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
-          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
-            '{"$inc":{"age":1}}'
-          );
-          done();
-        });
-      });
+          expect(spans[1].attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
+
+          done()
+        })
+      })
+    })
+
+    it('instrumenting deleteOne operation', async(done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        User.deleteOne({email: 'john.doe@example.com'})
+          .then(op => {
+            expect(op.deletedCount).toBe(1)
+            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+            expect(spans.length).toBe(1)
+
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('deleteOne')
+
+            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{"email":"john.doe@example.com"}')
+            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
+            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toBe(undefined)
+            done()
+          })
+      })
+    })
+
+    it('instrumenting updateOne operation on models', async(done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        User.findOne({ email: 'john.doe@example.com' })
+          .then(user => user!.updateOne({ $inc: {age: 1} }, { w: 1 }))
+          .then(user => {
+            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+            expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('updateOne')
+
+            expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toMatch(/{"_id":"\w+"}/)
+            expect(spans[1].attributes[AttributeNames.DB_OPTIONS]).toEqual('{"w":1}')
+            expect(spans[1].attributes[AttributeNames.DB_UPDATE]).toEqual('{"$inc":{"age":1}}')
+
+            expect(spans[1].attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
+
+            done()
+          })
+      })
+    })
+
+    it('instrumenting updateOne operation', async(done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        User.updateOne({ email: 'john.doe@example.com' }, { $inc: {age: 1} })
+          .then(user => {
+            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('updateOne')
+
+            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{"email":"john.doe@example.com"}')
+            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
+            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual('{"$inc":{"age":1}}')
+            done()
+          })
+      })
+    })
+
+    it('instrumenting count operation [deprecated]', async(done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        User.count({})
+          .then(users => {
+            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('count')
+
+            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{}')
+            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
+            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(undefined)
+            done()
+          })
+      })
+    })
+
+    it('instrumenting countDocuments operation', async(done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        User.countDocuments({})
+          .then(users => {
+            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+            expect(spans.length).toBe(1)
+
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('countDocuments')
+
+            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{}')
+            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
+            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(undefined)
+            done()
+          })
+      })
+    })
+
+    it('instrumenting estimatedDocumentCount operation', async(done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        User.estimatedDocumentCount({})
+          .then(users => {
+            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+            expect(spans.length).toBe(1)
+
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('estimatedDocumentCount')
+
+            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{}')
+            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
+            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(undefined)
+            done()
+          })
+      })
+    })
+
+    it('instrumenting deleteMany operation', async(done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        User.deleteMany({})
+          .then(users => {
+            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('deleteMany')
+
+            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{}')
+            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
+            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(undefined)
+            done()
+          })
+      })
+    })
+
+    it('instrumenting findOne operation', async(done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        User.findOne({ email: 'john.doe@example.com' })
+          .then(user => {
+            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('findOne')
+
+            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch('{"email":"john.doe@example.com"}')
+            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
+            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(undefined)
+            done()
+          })
+      })
+    })
+
+    it('instrumenting update operation', async(done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        User.update({ email: 'john.doe@example.com' }, { email: 'john.doe2@example.com' })
+          .then(user => {
+            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('update')
+
+            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{"email":"john.doe@example.com"}')
+            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
+            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual('{"email":"john.doe2@example.com"}')
+            done()
+          })
+      })
+    })
+
+    it('instrumenting updateMany operation', async(done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        User.updateMany({ age: 18}, { isDeleted: true })
+          .then(user => {
+            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('updateMany')
+
+            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{"age":18}')
+            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
+            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual('{"isDeleted":true}')
+            done()
+          })
+      })
     });
 
-    it("instrumenting count operation [deprecated]", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        User.count({}).then((users) => {
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+    it(`instrumenting findOneAndDelete operation`, async(done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        User.findOneAndDelete({ email: "john.doe@example.com" })
+          .then(() => {
+            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "count"
-          );
+            expect(spans.length).toBe(1)
 
-          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
-            "{}"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
-          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
-            undefined
-          );
-          done();
-        });
-      });
-    });
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('findOneAndDelete')
 
-    it("instrumenting countDocuments operation", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        User.countDocuments({}).then((users) => {
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{"email":"john.doe@example.com"}')
+            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
+            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(undefined)
+            done()
+          })
+      })
+    })
 
-          expect(spans.length).toBe(1);
+    it(`instrumenting findOneAndUpdate operation`, async(done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        User.findOneAndUpdate({ email: "john.doe@example.com" }, { isUpdated: true } )
+          .then(() => {
+            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "countDocuments"
-          );
+            expect(spans.length).toBe(2)
 
-          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
-            "{}"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
-          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
-            undefined
-          );
-          done();
-        });
-      });
-    });
+            expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('findOneAndUpdate')
 
-    it("instrumenting estimatedDocumentCount operation", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        User.estimatedDocumentCount({}).then((users) => {
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+            expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toEqual('{"email":"john.doe@example.com"}')
+            expect(spans[1].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
+            expect(spans[1].attributes[AttributeNames.DB_UPDATE]).toEqual('{"isUpdated":true}')
 
-          expect(spans.length).toBe(1);
+            done()
+          })
+      })
+    })
 
-          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "estimatedDocumentCount"
-          );
+    it(`instrumenting findOneAndRemove operation`, async(done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        User.findOneAndRemove({ email: "john.doe@example.com" } )
+          .then(() => {
+            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
-            "{}"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
-          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
-            undefined
-          );
-          done();
-        });
-      });
-    });
+            expect(spans.length).toBe(1)
 
-    it("instrumenting deleteMany operation", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        User.deleteMany({}).then((users) => {
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('findOneAndRemove')
 
-          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "deleteMany"
-          );
+            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual('{"email":"john.doe@example.com"}')
+            expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual('{}')
+            expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(undefined)
 
-          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
-            "{}"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
-          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
-            undefined
-          );
-          done();
-        });
-      });
-    });
+            done()
+          })
+      })
+    })
 
-    it("instrumenting findOne operation", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        User.findOne({ email: "john.doe@example.com" }).then((user) => {
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+    it(`instrumenting create operation`, async(done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        User.create({ firstName: 'John', lastName: 'Doe', email: "john.doe+1@example.com" } )
+          .then(() => {
+            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "findOne"
-          );
+            expect(spans.length).toBe(1)
+            assertSpan(spans[0])
 
-          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch(
-            '{"email":"john.doe@example.com"}'
-          );
-          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
-          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
-            undefined
-          );
-          done();
-        });
-      });
-    });
+            expect(spans[0].status.code).toEqual(CanonicalCode.OK)
 
-    it("instrumenting update operation", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        User.update(
-          { email: "john.doe@example.com" },
-          { email: "john.doe2@example.com" }
-        ).then((user) => {
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+            expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch('')
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('save')
 
-          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "update"
-          );
-
-          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
-            '{"email":"john.doe@example.com"}'
-          );
-          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
-          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
-            '{"email":"john.doe2@example.com"}'
-          );
-          done();
-        });
-      });
-    });
-
-    it("instrumenting updateMany operation", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        User.updateMany({ age: 18 }, { isDeleted: true }).then((user) => {
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "updateMany"
-          );
-
-          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
-            '{"age":18}'
-          );
-          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
-          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
-            '{"isDeleted":true}'
-          );
-          done();
-        });
-      });
-    });
-
-    it(`instrumenting findOneAndDelete operation`, async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        User.findOneAndDelete({ email: "john.doe@example.com" }).then(() => {
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-          expect(spans.length).toBe(1);
-
-          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "findOneAndDelete"
-          );
-
-          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
-            '{"email":"john.doe@example.com"}'
-          );
-          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
-          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
-            undefined
-          );
-          done();
-        });
-      });
-    });
-
-    it(`instrumenting findOneAndUpdate operation`, async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        User.findOneAndUpdate(
-          { email: "john.doe@example.com" },
-          { isUpdated: true }
-        ).then(() => {
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-          expect(spans.length).toBe(2);
-
-          expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "findOneAndUpdate"
-          );
-
-          expect(spans[1].attributes[AttributeNames.DB_STATEMENT]).toEqual(
-            '{"email":"john.doe@example.com"}'
-          );
-          expect(spans[1].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
-          expect(spans[1].attributes[AttributeNames.DB_UPDATE]).toEqual(
-            '{"isUpdated":true}'
-          );
-
-          done();
-        });
-      });
-    });
-
-    it(`instrumenting findOneAndRemove operation`, async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        User.findOneAndRemove({ email: "john.doe@example.com" }).then(() => {
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-          expect(spans.length).toBe(1);
-
-          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "findOneAndRemove"
-          );
-
-          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toEqual(
-            '{"email":"john.doe@example.com"}'
-          );
-          expect(spans[0].attributes[AttributeNames.DB_OPTIONS]).toEqual("{}");
-          expect(spans[0].attributes[AttributeNames.DB_UPDATE]).toEqual(
-            undefined
-          );
-
-          done();
-        });
-      });
-    });
-
-    it(`instrumenting create operation`, async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        User.create({
-          firstName: "John",
-          lastName: "Doe",
-          email: "john.doe+1@example.com",
-        }).then(() => {
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-          expect(spans.length).toBe(1);
-          assertSpan(spans[0]);
-
-          expect(spans[0].status.code).toEqual(CanonicalCode.OK);
-
-          expect(spans[0].attributes[AttributeNames.DB_STATEMENT]).toMatch("");
-          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-            "save"
-          );
-
-          done();
-        });
-      });
-    });
+            done()
+          })
+      })
+    })
 
     it("instrumenting aggregate operation", async (done) => {
       const span = provider.getTracer("default").startSpan("test span");
@@ -828,123 +642,90 @@ describe("mongoose opentelemetry plugin", () => {
     });
 
     it("await on mongoose thenable query object", async (done) => {
-      const initSpan: Span = provider
-        .getTracer("default")
-        .startSpan("test span");
-      provider.getTracer("default").withSpan(initSpan, async () => {
-        await User.findOne({ id: "_test" });
+      const initSpan: Span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(initSpan, async () => {
+
+        await User.findOne({id: "_test"});
 
         const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
         expect(spans.length).toBe(1);
         const mongooseSpan: ReadableSpan = spans[0];
 
         // validate the the mongoose span is the child of the span the initiated the call
-        expect(mongooseSpan.spanContext.traceId).toEqual(
-          initSpan.context().traceId
-        );
+        expect(mongooseSpan.spanContext.traceId).toEqual(initSpan.context().traceId);
         expect(mongooseSpan.parentSpanId).toEqual(initSpan.context().spanId);
 
         assertSpan(mongooseSpan);
-        expect(mongooseSpan.attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-          "User"
-        );
-        expect(mongooseSpan.attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-          "findOne"
-        );
+        expect(mongooseSpan.attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+        expect(mongooseSpan.attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('findOne')
 
-        expect(mongooseSpan.attributes[AttributeNames.DB_STATEMENT]).toEqual(
-          '{"id":"_test"}'
-        );
+        expect(mongooseSpan.attributes[AttributeNames.DB_STATEMENT]).toEqual('{"id":"_test"}')
 
-        expect(mongooseSpan.attributes[AttributeNames.COLLECTION_NAME]).toEqual(
-          "users"
-        );
+        expect(mongooseSpan.attributes[AttributeNames.COLLECTION_NAME]).toEqual('users')
 
-        done();
-      });
-    });
+        done()
+      })
+    })
 
     it("instrumenting combined operation with Promise.all", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
         Promise.all([
-          User.find({ id: "_test" }).skip(1).limit(2).sort({ email: "asc" }),
-          User.countDocuments(),
-        ]).then((users) => {
-          // close the root span
-          span.end();
-
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-
-          // same traceId assertion
-          expect(
-            [
-              ...new Set(
-                spans.map((span: ReadableSpan) => span.spanContext.traceId)
-              ),
-            ].length
-          ).toBe(1);
-
-          expect(spans.length).toBe(3);
-
-          assertSpan(spans[0]);
-          assertSpan(spans[1]);
-
-          expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toMatch(
-            /^(find|countDocuments)$/g
-          );
-
-          expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-            "User"
-          );
-          expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toMatch(
-            /^(find|countDocuments)$/g
-          );
-
-          done();
-        });
-      });
-    });
-
-    it("instrumenting combined operation with async/await", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, async () => {
-        await User.find({ id: "_test" })
+          User
+          .find({id: "_test"})
           .skip(1)
           .limit(2)
-          .sort({ email: "asc" });
+          .sort({email: 'asc'}),
+          User.countDocuments()
+        ])
+          .then((users) => {
+            // close the root span
+            span.end()
+
+            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+
+            // same traceId assertion
+            expect([...new Set(spans.map((span: ReadableSpan) => span.spanContext.traceId))].length).toBe(1)
+
+            expect(spans.length).toBe(3)
+
+            assertSpan(spans[0])
+            assertSpan(spans[1])
+
+            expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toMatch(/^(find|countDocuments)$/g)
+
+            expect(spans[1].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+            expect(spans[1].attributes[AttributeNames.DB_QUERY_TYPE]).toMatch(/^(find|countDocuments)$/g)
+
+            done()
+          })
+      })
+    })
+
+    it("instrumenting combined operation with async/await", async (done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, async () => {
+        await User.find({id: "_test"}).skip(1).limit(2).sort({email: 'asc'})
         // close the root span
-        span.end();
+        span.end()
 
         const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-        expect(spans.length).toBe(2);
+        expect(spans.length).toBe(2)
 
         // same traceId assertion
-        expect(
-          [
-            ...new Set(
-              spans.map((span: ReadableSpan) => span.spanContext.traceId)
-            ),
-          ].length
-        ).toBe(1);
+        expect([...new Set(spans.map((span: ReadableSpan) => span.spanContext.traceId))].length).toBe(1)
 
-        assertSpan(spans[0]);
+        assertSpan(spans[0])
 
-        expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual(
-          "User"
-        );
-        expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual(
-          "find"
-        );
+        expect(spans[0].attributes[AttributeNames.DB_MODEL_NAME]).toEqual('User')
+        expect(spans[0].attributes[AttributeNames.DB_QUERY_TYPE]).toEqual('find')
 
-        done();
-      });
-    });
-  });
+        done()
+      })
+    })
+  })
 
   describe("Trace with enhancedDatabaseReporting", () => {
     let contextManager: AsyncHooksContextManager;
@@ -953,65 +734,58 @@ describe("mongoose opentelemetry plugin", () => {
     provider.addSpanProcessor(spanProcessor);
 
     beforeAll(() => {
-      plugin.enable(mongoose, provider, logger, {
-        enhancedDatabaseReporting: true,
-      });
-    });
+      plugin.enable(mongoose, provider, logger, { enhancedDatabaseReporting: true });
+    })
 
     afterAll(() => {
       plugin.disable();
-    });
+    })
 
     beforeEach(() => {
       memoryExporter.reset();
       contextManager = new AsyncHooksContextManager().enable();
       context.setGlobalContextManager(contextManager);
-    });
+    })
 
     afterEach(() => {
       contextManager.disable();
     });
 
-    it(`Save operation traces save data`, async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        const payload = {
-          firstName: "John",
-          lastName: "Doe",
-          email: "john.doe+1@example.com",
-        };
-        User.create(payload).then((user) => {
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+    it(`Save operation traces save data`, async(done) => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        const payload = { firstName: 'John', lastName: 'Doe', email: "john.doe+1@example.com" };
+        User.create(payload)
+          .then((user) => {
+            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
 
-          expect(spans.length).toBe(1);
-          assertSpan(spans[0]);
+            expect(spans.length).toBe(1)
+            assertSpan(spans[0])
 
-          const saveData = JSON.parse(
-            spans[0].attributes[AttributeNames.DB_SAVE] as string
-          );
-          expect(saveData.firstName).toBe(payload.firstName);
-          expect(saveData.lastName).toBe(payload.lastName);
-          expect(saveData.email).toBe(payload.email);
-          expect(saveData._id).toBeDefined();
+            const saveData = JSON.parse(spans[0].attributes[AttributeNames.DB_SAVE] as string);
+            expect(saveData.firstName).toBe(payload.firstName);
+            expect(saveData.lastName).toBe(payload.lastName);
+            expect(saveData.email).toBe(payload.email);
+            expect(saveData._id).toBeDefined();
 
-          done();
-        });
+            done()
+          })
       });
     });
 
     it("find operation traces query response", async (done) => {
-      const span = provider.getTracer("default").startSpan("test span");
-      provider.getTracer("default").withSpan(span, () => {
-        User.find({}).then((users) => {
-          const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
-          assertSpan(spans[0]);
-          expect(JSON.stringify(users)).toEqual(
-            spans[0].attributes[AttributeNames.DB_RESPONSE] as string
-          );
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        User.find({})
+          .then((users) => {
+            const spans: ReadableSpan[] = memoryExporter.getFinishedSpans();
+            assertSpan(spans[0]);
+            expect(JSON.stringify(users)).toEqual(spans[0].attributes[AttributeNames.DB_RESPONSE] as string);
 
-          done();
-        });
-      });
-    });
-  });
+            done()
+          })
+      })
+    })
+
+  })
 });

--- a/spec/index-spec.ts
+++ b/spec/index-spec.ts
@@ -611,7 +611,7 @@ describe("mongoose opentelemetry plugin", () => {
       })
     })
 
-    it("instrumenting aggregate operation", async (done) => {
+    it('instrumenting aggregate operation', async (done) => {
       const span = provider.getTracer("default").startSpan("test span");
       provider.getTracer("default").withSpan(span, () => {
         User.aggregate([

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -16,4 +16,5 @@ export enum AttributeNames {
   DB_MODEL = 'db.doc',
   DB_MODEL_NAME = 'mongoose.model',
   DB_QUERY_TYPE = 'mongoose.query',
+  DB_AGGREGATE_PIPELINE = 'mongoose.db.aggregate_pipeline',
 }

--- a/src/mongoose.ts
+++ b/src/mongoose.ts
@@ -4,7 +4,7 @@ import mongoose from 'mongoose';
 
 import { AttributeNames } from './enums'
 
-import { startSpan, handleError, setErrorStatus, safeStringify } from './utils'
+import { startSpan, handleError, setErrorStatus, safeStringify, getAttributesFromCollection, handleExecResponse } from './utils'
 
 import { VERSION } from './version'
 
@@ -37,14 +37,34 @@ export class MongoosePlugin extends BasePlugin<typeof mongoose> {
     shimmer.wrap(this._moduleExports.Model.prototype, 'save', this.patchOnModelMethods('save'));
     shimmer.wrap(this._moduleExports.Model.prototype, 'remove', this.patchOnModelMethods('remove'));
     shimmer.wrap(this._moduleExports.Query.prototype, 'exec', this.patchQueryExec());
+    shimmer.wrap(this._moduleExports.Aggregate.prototype, 'exec', this.patchAggregateExec());
 
     contextCaptureFunctions.forEach( (funcName: string) => {
       shimmer.wrap(this._moduleExports.Query.prototype, funcName as any, this.patchAndCaptureSpanContext(funcName));
     })
+    shimmer.wrap(this._moduleExports.Model, 'aggregate' as any, this.patchModelAggregate());
 
-    shimmer.wrap(this._moduleExports.Query.prototype, 'then', this.patchQueryThen());
+    shimmer.wrap(this._moduleExports.Query.prototype, 'then', this.patchMongooseThen('Query'));
+    shimmer.wrap(this._moduleExports.Aggregate.prototype, 'then', this.patchMongooseThen('Aggregate'));
     
     return this._moduleExports;
+  }
+
+  private patchAggregateExec() {
+    const thisPlugin = this;
+    thisPlugin._logger.debug('MongoosePlugin: patched mongoose query exec prototype');
+    return (originalExec: Function) => {
+      return function exec(this: any) {
+        let span = startSpan(thisPlugin._tracer, this._model?.modelName, 'aggregate');
+        span.setAttributes(getAttributesFromCollection(this._model.collection));
+        span.setAttribute(AttributeNames.DB_QUERY_TYPE, 'aggregate');
+        span.setAttribute(AttributeNames.DB_OPTIONS, JSON.stringify(this.options));
+        span.setAttribute(AttributeNames.DB_AGGREGATE_PIPELINE, JSON.stringify(this._pipeline));
+        
+        const aggregateResponse = originalExec.apply(this, arguments);
+        return handleExecResponse(aggregateResponse, span, thisPlugin?._config?.enhancedDatabaseReporting);
+      }
+    }
   }
 
   private patchQueryExec() {
@@ -54,12 +74,7 @@ export class MongoosePlugin extends BasePlugin<typeof mongoose> {
       return function exec(this: any) {
         let span = startSpan(thisPlugin._tracer, this.model.modelName, this.op);
 
-        span.setAttribute(AttributeNames.COLLECTION_NAME, this.mongooseCollection.name)
-
-        span.setAttribute(AttributeNames.DB_NAME, this.mongooseCollection.conn.name)
-        span.setAttribute(AttributeNames.DB_HOST, this.mongooseCollection.conn.host)
-        span.setAttribute(AttributeNames.DB_PORT, this.mongooseCollection.conn.port)
-        span.setAttribute(AttributeNames.DB_USER, this.mongooseCollection.conn.user)
+        span.setAttributes(getAttributesFromCollection(this.mongooseCollection));
 
         span.setAttribute(AttributeNames.DB_QUERY_TYPE, this.op)
         span.setAttribute(AttributeNames.DB_STATEMENT, JSON.stringify(this._conditions))
@@ -67,21 +82,7 @@ export class MongoosePlugin extends BasePlugin<typeof mongoose> {
         span.setAttribute(AttributeNames.DB_UPDATE, JSON.stringify(this._update))
 
         const queryResponse = originalExec.apply(this, arguments)
-
-        if (!(queryResponse instanceof Promise)) {
-          span.end()
-          return queryResponse
-        }
-        
-        return queryResponse
-          .then(response => {
-            if (thisPlugin?._config?.enhancedDatabaseReporting) {
-              span.setAttribute(AttributeNames.DB_RESPONSE, safeStringify(response));
-            }
-            return response;
-          })
-          .catch(handleError(span))
-          .finally(() => span.end())
+        return handleExecResponse(queryResponse, span, thisPlugin?._config?.enhancedDatabaseReporting);
       }
     }
   }
@@ -92,15 +93,9 @@ export class MongoosePlugin extends BasePlugin<typeof mongoose> {
     return (originalOnModelFunction: Function) => {
       return function method(this: any, options?: any, fn?: Function) {
         let span = startSpan(thisPlugin._tracer, this.constructor.modelName, op);
+        span.setAttributes(getAttributesFromCollection(this.constructor.collection));
 
         span.setAttribute(AttributeNames.DB_QUERY_TYPE, op)
-
-        span.setAttribute(AttributeNames.DB_NAME, this.constructor.collection.conn.name)
-        span.setAttribute(AttributeNames.DB_HOST, this.constructor.collection.conn.host)
-        span.setAttribute(AttributeNames.DB_PORT, this.constructor.collection.conn.port)
-        span.setAttribute(AttributeNames.DB_USER, this.constructor.collection.conn.user)
-
-        span.setAttribute(AttributeNames.COLLECTION_NAME, this.constructor.collection.name)
 
         if (thisPlugin?._config?.enhancedDatabaseReporting) {
           span.setAttribute(AttributeNames.DB_SAVE, safeStringify(this));
@@ -128,6 +123,23 @@ export class MongoosePlugin extends BasePlugin<typeof mongoose> {
     }
   }
 
+  // we want to capture the otel span on the object which is calling exec.
+  // in the special case of aggregate, we need have no function to path
+  // on the Aggregate object to capture the context on, so we patch
+  // the aggregate of Model, and set the context on the Aggregate object
+  private patchModelAggregate() {
+    const thisPlugin = this
+    thisPlugin._logger.debug(`MongoosePlugin: patched mongoose model aggregate`);
+    return (original: Function) => {
+      return function captureSpanContext(this: any) {
+        const currentSpan = thisPlugin._tracer.getCurrentSpan();
+        const aggregate = original.apply(this, arguments);
+        if(aggregate) aggregate._otContext = currentSpan;
+        return aggregate;
+      }
+    }
+  }
+
   private patchAndCaptureSpanContext(funcName: string) {
     const thisPlugin = this
     thisPlugin._logger.debug(`MongoosePlugin: patched mongoose query ${funcName} prototype`);
@@ -139,9 +151,9 @@ export class MongoosePlugin extends BasePlugin<typeof mongoose> {
     }
   }
 
-  private patchQueryThen() {
+  private patchMongooseThen(patchedObject: string) {
     const thisPlugin = this
-    thisPlugin._logger.debug('MongoosePlugin: patched mongoose query then prototype');
+    thisPlugin._logger.debug(`MongoosePlugin: patched ${patchedObject} then prototype`);
     return (originalThen: Function) => {
       return function patchedThen(this: any) {
         if(this._otContext) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { Tracer } from '@opentelemetry/api'
+import { Tracer, Attributes } from '@opentelemetry/api'
 import { CanonicalCode, Span, SpanKind } from '@opentelemetry/api';
 import { MongoError } from 'mongodb'
 import { AttributeNames } from './enums';
@@ -12,6 +12,23 @@ export function startSpan(tracer: Tracer, name: string, op: string): Span {
       [AttributeNames.COMPONENT]: 'mongoose',
     },
   })
+}
+
+export function handleExecResponse(execResponse: any, span: Span, enhancedDatabaseReporting?: boolean): any {
+  if (!(execResponse instanceof Promise)) {
+    span.end()
+    return execResponse
+  }
+  
+  return execResponse
+    .then(response => {
+      if (enhancedDatabaseReporting) {
+        span.setAttribute(AttributeNames.DB_RESPONSE, safeStringify(response));
+      }
+      return response;
+    })
+    .catch(handleError(span))
+    .finally(() => span.end())
 }
 
 export function handleError(span: Span) {
@@ -45,4 +62,14 @@ export function safeStringify(payload: any): string | null {
   } catch {
     return null;
   }
+}
+
+export function getAttributesFromCollection(collection: any): Attributes {
+  return {
+    [AttributeNames.COLLECTION_NAME]: collection.name,
+    [AttributeNames.DB_NAME]: collection.conn.name,
+    [AttributeNames.DB_HOST]: collection.conn.host,
+    [AttributeNames.DB_PORT]: collection.conn.port,
+    [AttributeNames.DB_USER]: collection.conn.user,
+  };
 }


### PR DESCRIPTION
Fixes #38 

Aggregate calls are executed by an `Aggregate` object in mongoose. 
This object is currently not patched, and `aggregate` calls are not instrumented in the plugin.

This PR:
- patches the `exec` function of `Aggregate`, in a similar way to `Query.exec` patch, and starts a span when aggregate is executed. The patch attaches relevant attributes like the aggregate pipeline.
- patches the `aggregate` function of `Model`, to store otel context on function call.
- patches the `then` function of `Aggregate`, so plugin can restore otel context on thenable await.