### PR TITLE
refactor: set new span parent with startSpan option 

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import { CanonicalCode, Span, SpanKind } from '@opentelemetry/api';
 import { MongoError } from 'mongodb'
 import { AttributeNames } from './enums';
 
-export function startSpan(tracer: Tracer, name: string, op: string): Span {
+export function startSpan(tracer: Tracer, name: string, op: string, parentSpan?: Span): Span {
   return tracer.startSpan(`mongoose.${name}.${op}`, {
     kind: SpanKind.CLIENT,
     attributes: {
@@ -11,6 +11,7 @@ export function startSpan(tracer: Tracer, name: string, op: string): Span {
       [AttributeNames.DB_TYPE]: 'nosql',
       [AttributeNames.COMPONENT]: 'mongoose',
     },
+    parent: parentSpan
   })
 }
 


### PR DESCRIPTION
instead of withSpan block.

Fixes #35 

This PR:
- Set the new span parent with the relevant options from Tracer's `startSpan` function.
- Remove the patching for the `then` function on `Query` and `Aggregate` (since they were only setting the span context with `withSpan()`, which is no longer needed).
- Store the original parent span on the `Query` \ `Aggregate` with Symbol instead of plain string.
- Adds missing unwrap, forgotten in the previous PR.
- Small fixes to log printing